### PR TITLE
Fix x points when z0!=0.0

### DIFF
--- a/src/solovev.jl
+++ b/src/solovev.jl
@@ -439,7 +439,7 @@ Keyword Arguments:\\
 
             c = SVector{7}(Ψ_h[1:7,1:7]'\(-Ψ_p[1:7]))
         else
-            xsep, ysep = x_point[1]/R0, (x_point[2] - Z0)/R0 # normalize x_point
+            xsep, ysep = x_point[1]/R0, (x_point[2] - 2 * Z0)/R0 # normalize x_point
 
             # Eq. 12
             # Outer equatorial point
@@ -474,7 +474,7 @@ Keyword Arguments:\\
             c = SVector{7}(Ψ_h[1:7,1:7]'\(-Ψ_p[1:7]))
         end
     else
-        xsep, ysep = x_point[1]/R0, (x_point[2] - Z0)/R0 # normalize x_point
+        xsep, ysep = x_point[1]/R0, (x_point[2] - 2 * Z0)/R0 # normalize x_point
         if ysep > 0
             throw(ArgumentError("X-point should be below the midplane"))
         end
@@ -533,10 +533,10 @@ Keyword Arguments:\\
     end
 
     if !symmetric
-        x,y = shape(S,N=100, normed=true)
+        x,y = shape(S, N=100, normed=true)
         bdry = PlasmaBoundary(collect(zip(x,y)))
     else
-        rlims, zlims = limits(S,x_point)
+        rlims, zlims = limits(S, x_point)
         xmin,xmax = rlims ./ R0
         ymin,ymax = (zlims .- Z0) ./ R0
         x = xmin:0.01:xmax


### PR DESCRIPTION
Without this fix the x-point Z coordinate is wrong by a value of Z0.

Example shows the `x_point` is at `(5.0,-2.0)` and not `(5.0,-3.0)` as was originally input.

<img width="834" alt="image" src="https://user-images.githubusercontent.com/1537880/215772126-71cdae5b-f884-4590-938a-bacadd812ee6.png">

with the fix things work as requested

<img width="810" alt="image" src="https://user-images.githubusercontent.com/1537880/215773224-0bca2c57-b30c-4235-86a3-98e5ab43846c.png">

