### PR TITLE
Remove MeshTools from dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,6 @@ Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 LRUCache = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Memoize = "c03570c3-d221-55d1-a50c-7939bbd78826"
-MeshTools = "804828d9-b4e9-4eca-b847-748d6c7bafa9"
 MillerExtendedHarmonic = "c82744c2-dc08-461a-8c37-87ab04d0f9b8"
 NetCDF = "30363a11-5582-574a-97bb-aa9a979735b9"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
@@ -21,9 +20,6 @@ PolygonOps = "647866c9-e3ac-4575-94e7-e3d426903924"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Trapz = "592b5752-818d-11e9-1e9a-2b8ca4a44cd1"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
-
-[extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Contour = "0.6"
@@ -34,7 +30,6 @@ HCubature = "1"
 Interpolations = "0.14.7, 0.15"
 LRUCache = "1"
 Memoize = "0.4"
-MeshTools = "1"
 MillerExtendedHarmonic = "1"
 NetCDF = "0.12"
 Optim = "1"
@@ -42,6 +37,9 @@ PolygonOps = "0.1"
 StaticArrays = "1"
 Trapz = "2"
 Zygote = "0.6"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]

--- a/src/MXHEquilibrium.jl
+++ b/src/MXHEquilibrium.jl
@@ -12,8 +12,6 @@ using Trapz
 using Memoize
 using LRUCache
 
-using MeshTools
-
 import PolygonOps
 import Contour
 import Optim


### PR DESCRIPTION
From what I can tell, this dependency isn't used anymore in this package.